### PR TITLE
Fixed 19 issues of type: PYTHON_E402 throughout 10 files in repo.

### DIFF
--- a/midonet/neutron/db/migration/alembic_migration/versions/19808c5df22a_add_agent_membership.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/19808c5df22a_add_agent_membership.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """add agent membership
 
 Revision ID: 19808c5df22a
@@ -24,8 +26,6 @@ Create Date: 2015-02-26 14:39:25.219125
 revision = '19808c5df22a'
 down_revision = 'd8a5c672761'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/25aeae45d4ad_add_task.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/25aeae45d4ad_add_task.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """add task
 
 Revision ID: 25aeae45d4ad
@@ -24,8 +26,6 @@ Create Date: 2014-10-27 13:26:15.053541
 revision = '25aeae45d4ad'
 down_revision = 'start_neutron_midonet'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/3fe2bca71c72_add_port_binding.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/3fe2bca71c72_add_port_binding.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """add port binding
 
 Revision ID: 3fe2bca71c72
@@ -24,8 +26,6 @@ Create Date: 2015-02-16 05:24:01.270141
 revision = '3fe2bca71c72'
 down_revision = '19808c5df22a'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/421564f630b1_add_dynamic_routing.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/421564f630b1_add_dynamic_routing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """add dynamic routing
 
 Revision ID: 421564f630b1
@@ -24,8 +26,6 @@ Create Date: 2015-03-31 04:40:24.533580
 revision = '421564f630b1'
 down_revision = '3fe2bca71c72'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/d8a5c672761_add_data_sync.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/d8a5c672761_add_data_sync.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+from alembic import op
+import sqlalchemy as sa
 """add data sync
 
 Revision ID: d8a5c672761
@@ -24,10 +27,7 @@ Create Date: 2015-03-16 06:04:40.695379
 revision = 'd8a5c672761'
 down_revision = '25aeae45d4ad'
 
-import datetime
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/3df8cd6d2ada_add_midonet_gateway_network_vlan_devices.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/3df8cd6d2ada_add_midonet_gateway_network_vlan_devices.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """add midonet gateway network vlan devices
 
 Revision ID: 3df8cd6d2ada
@@ -24,8 +26,6 @@ Create Date: 2016-04-13 07:03:39.557871
 revision = '3df8cd6d2ada'
 down_revision = 'cfe0dea89aa'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/4f3b347ea1c2_revert_dynamic_routing.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/4f3b347ea1c2_revert_dynamic_routing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
 """Revert dynamic routing
 
 Revision ID: 4f3b347ea1c2
@@ -24,7 +25,6 @@ Create Date: 2015-12-04 15:01:34.026502
 revision = '4f3b347ea1c2'
 down_revision = '29cbb88b092'
 
-from alembic import op
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/cfe0dea89aa_add_gateway_device_management.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/cfe0dea89aa_add_gateway_device_management.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from alembic import op
+import sqlalchemy as sa
 """add gateway device management
 
 Revision ID: cfe0dea89aa
@@ -23,8 +25,6 @@ Create Date: 2015-12-21 11:06:46.155138
 revision = 'cfe0dea89aa'
 down_revision = '4f3b347ea1c2'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/f8b289f2644f_bgp_speaker_router_insertion.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/mitaka/expand/f8b289f2644f_bgp_speaker_router_insertion.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
+import sqlalchemy as sa
 """bgp speaker router insertion
 
 Revision ID: f8b289f2644f
@@ -24,8 +26,6 @@ Create Date: 2016-05-13 10:14:14.939657
 revision = 'f8b289f2644f'
 down_revision = '3df8cd6d2ada'
 
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/midonet/neutron/db/migration/alembic_migration/versions/stein/contract/f5dfd5cefbc7_drop_fwaas_v1_and_logging_resource.py
+++ b/midonet/neutron/db/migration/alembic_migration/versions/stein/contract/f5dfd5cefbc7_drop_fwaas_v1_and_logging_resource.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from alembic import op
 """Drop FWaaS v1 and logging_resource
 
 Revision ID: f5dfd5cefbc7
@@ -24,7 +25,6 @@ Create Date: 2019-02-05 15:51:24.345127
 revision = 'f5dfd5cefbc7'
 down_revision = '1612b5389e6e'
 
-from alembic import op
 
 
 def upgrade():


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.